### PR TITLE
refresh session automatically on android

### DIFF
--- a/demo/app/app.css
+++ b/demo/app/app.css
@@ -1,1 +1,6 @@
 ﻿@import '~nativescript-theme-core/css/core.light.css';
+
+
+.btn {
+  margin: 0;
+}

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -10,7 +10,9 @@
         <Button class="btn" text="Register" tap="{{ register }}"/>
         <Button class="btn" text="Login" tap="{{ login }}"/>
         <Button class="btn" text="Active" tap="{{ active }}"/>
+        <Button class="btn" text="Auth" tap="{{ auth }}"/>
         <Button class="btn" text="Forget" tap="{{ forgot }}"/>
         <Button class="btn" text="Confirm Forget" tap="{{ confirmForgot }}"/>
+        <Button class="btn" text="Logout" tap="{{ logout }}"/>
     </StackLayout>
 </Page>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -1,5 +1,6 @@
+import * as dialogs from "tns-core-modules/ui/dialogs";
 import {Observable} from 'tns-core-modules/data/observable';
-import {Cognito} from 'nativescript-cognito';
+import {Cognito, Region} from 'nativescript-cognito';
 import {categories} from "tns-core-modules/trace";
 import Debug = categories.Debug;
 
@@ -15,7 +16,7 @@ export class HelloWorldModel extends Observable {
     }
 
     init() {
-        this.cognito = new Cognito("pool-id", "client-id");
+        this.cognito = new Cognito("pool-id", "client-id", null, Region.US_EAST_1);
     }
 
     async login() {
@@ -23,9 +24,32 @@ export class HelloWorldModel extends Observable {
             console.log("Hello");
             let data = await this.cognito.authenticate(this.email, this.password);
             let details = await this.cognito.getUserDetails();
-            console.log(data);
+            console.log(data.isValid);
+            console.log(data.isValidForThreshold);
             console.log(details.attributes);
             console.log(details.settings);
+        } catch (e) {
+            console.log(e);
+        }
+    }
+
+    async auth() {
+        try {
+            let data = await this.cognito.getCurrentUserSession();
+            console.log("Token issuedAt: ", data.idToken.issuedAt);
+            console.log("Token expiration: ", data.idToken.expiration);
+            await dialogs.alert(`Auth check success: ${data.idToken.expiration}`);
+        } catch (e) {
+            console.log(e);
+            await dialogs.alert("Auth check failed");
+        }
+
+    }
+
+    async logout() {
+        try {
+            await this.cognito.logout();
+            dialogs.alert("Logout success");
         } catch (e) {
             console.log(e);
         }

--- a/src/cognito.android.ts
+++ b/src/cognito.android.ts
@@ -192,12 +192,9 @@ export class Cognito extends Common {
                 // },
                 // authenticationChallenge(continuation) {
                 // },
-                // getAuthenticationDetails(continuation, userID) {
-                //     const authDetails = new AuthenticationDetails(userId, password, null);
-                //
-                //     continuation.setAuthenticationDetails(authDetails);
-                //     continuation.continueTask();
-                // },
+                getAuthenticationDetails(continuation, userID) {
+                     reject("User is not authenticated");
+                },
                 onSuccess(session, newDevice) {
                     const data = Cognito.getSessionObject(session);
                     this.session = data;
@@ -207,7 +204,7 @@ export class Cognito extends Common {
                     reject(Cognito.getErrorObject(exception));
                 }
             });
-            this.getCurrentUser().getSession(callBack);
+            this.getCurrentUser().getSessionInBackground(callBack);
         });
     }
 
@@ -272,9 +269,9 @@ export class Cognito extends Common {
                 issuedAt: session.getIdToken().getIssuedAt(),
                 token: session.getIdToken().getJWTToken(),
             },
-            isValidForThreshold: session.isValidForThreshold,
+            isValidForThreshold: session.isValidForThreshold(),
             username: session.getUsername(),
-            isValid: session.isValid,
+            isValid: session.isValid(),
         } as UserSession
     );
 


### PR DESCRIPTION
## What is the current behavior?
This problem exist only on android
1. Login 
2. Call getCurrentUserSession()
3. Wait one hour
4. Call getCurrentUserSession()

Observed
Session not refreshed and error is thrown
Expected:
Session being automatically refreshed (works fine on iOS)

## What is the new behavior?
Following suggestion from below [stackoverflow](https://stackoverflow.com/questions/51120553/aws-cognito-on-android-how-to-get-a-new-session-from-a-refresh-token), it seems that plugin should use getSessionInBackground instead of getSession. 

Not sure about the code change in getAuthenticationDetails, have tried the                     continuation.continueTask(), but it was throwing null pointer exception when user was logged out. 

Fixes - https://github.com/papmodern/nativescript-cognito/issues/2